### PR TITLE
FLGO-69 New forum message

### DIFF
--- a/docs/generated.md
+++ b/docs/generated.md
@@ -674,7 +674,7 @@
 
 
 
-**GET** [/v1/blog_articles/{id}](../sources/server/internal/endpoints/show_article.go#L13)
+**GET** [/v1/blog_articles/{id}](../sources/server/internal/endpoints/show_article.go#L12)
 
 Параметры запроса:
 
@@ -913,6 +913,34 @@
 
 ## С проверкой на бан
 
+
+<details><summary>Создание нового сообщения в форуме</summary>
+<p>
+
+
+
+**POST** [/v1/topics/{id}/message](../sources/server/internal/endpoints/add_forum_message.go#L12)
+
+Параметры запроса:
+
+
+* **id** (path, uint64) - id темы
+
+
+* **message** (form, string) - текст сообщения
+
+
+
+
+Схема ответа:
+
+```
+{}
+```
+---
+
+</p>
+</details>
 
 <details><summary>Подписка/отписка от темы форума</summary>
 <p>

--- a/sources/server/internal/app/memcache.go
+++ b/sources/server/internal/app/memcache.go
@@ -2,14 +2,26 @@ package app
 
 import (
 	"context"
+	"fantlab/base/memcached"
 	"fmt"
 	"strconv"
 	"time"
 )
 
-const articleLikeCountKey string = "blog:topic:likes:%d"
+const (
+	userKey             = "users:user_id=%d"
+	articleLikeCountKey = "blog:topic:likes:%d"
+)
 
-func (s *Services) GetBlogArticleLikeCount(ctx context.Context, articleId uint64) (uint64, error) {
+func (s *Services) DeleteUserCache(ctx context.Context, userId uint64) error {
+	err := s.memcache.Delete(ctx, fmt.Sprintf(userKey, userId))
+	if err != nil && !memcached.IsNotFoundError(err) {
+		return err
+	}
+	return nil
+}
+
+func (s *Services) GetBlogArticleLikeCountCache(ctx context.Context, articleId uint64) (uint64, error) {
 	likeCountBytes, err := s.memcache.Get(ctx, fmt.Sprintf(articleLikeCountKey, articleId))
 
 	if err != nil {
@@ -21,7 +33,7 @@ func (s *Services) GetBlogArticleLikeCount(ctx context.Context, articleId uint64
 	return uint64(likeCount), err
 }
 
-func (s *Services) SetBlogArticleLikeCount(ctx context.Context, articleId, likeCount uint64) error {
+func (s *Services) SetBlogArticleLikeCountCache(ctx context.Context, articleId, likeCount uint64) error {
 	bytes := []byte(strconv.Itoa(int(likeCount)))
 	return s.memcache.Set(ctx, fmt.Sprintf(articleLikeCountKey, articleId), bytes, time.Now().Add(1*time.Hour))
 }

--- a/sources/server/internal/config/app.go
+++ b/sources/server/internal/config/app.go
@@ -15,6 +15,8 @@ type AppConfig struct {
 	BlogTopicsInPage      uint64
 	ForumTopicsInPage     uint64
 	ForumMessagesInPage   uint64
+	MaxForumMessageLength uint64
 	DefaultAccessToForums []uint64
 	CensorshipText        string
+	BotUserId             uint64
 }

--- a/sources/server/internal/converters/forum.go
+++ b/sources/server/internal/converters/forum.go
@@ -103,7 +103,7 @@ func GetForumTopics(dbResponse *db.ForumTopicsDBResponse, page, limit uint64, cf
 		lastMessageUserAvatar := helpers.GetUserAvatarUrl(cfg.ImagesBaseURL, dbTopic.LastUserID, dbTopic.LastPhotoNumber)
 
 		topic := &pb.Forum_Topic{
-			Id:        dbTopic.TopicID,
+			Id:        dbTopic.TopicId,
 			Title:     dbTopic.Name,
 			TopicType: topicType,
 			Creation: &pb.Common_Creation{

--- a/sources/server/internal/db/forum_test.go
+++ b/sources/server/internal/db/forum_test.go
@@ -240,7 +240,7 @@ func Test_FetchForumTopics(t *testing.T) {
 		assert.DeepEqual(t, topics, &ForumTopicsDBResponse{
 			Topics: []ForumTopic{
 				{
-					TopicID:         327,
+					TopicId:         327,
 					Name:            "Раздел \"Авторы, книги\"",
 					DateOfAdd:       now,
 					Views:           519,
@@ -259,7 +259,7 @@ func Test_FetchForumTopics(t *testing.T) {
 					LastMessageDate: now,
 				},
 				{
-					TopicID:         47,
+					TopicId:         47,
 					Name:            "Хочу застолбить за собой автора!",
 					DateOfAdd:       now,
 					Views:           1969,

--- a/sources/server/internal/db/forum_votes.go
+++ b/sources/server/internal/db/forum_votes.go
@@ -1,0 +1,52 @@
+package db
+
+import (
+	"context"
+	"fantlab/base/codeflow"
+	"fantlab/base/dbtools"
+	"fantlab/base/dbtools/sqlr"
+	"fantlab/server/internal/db/queries"
+)
+
+func (db *DB) UpdateForumMessageVotedPlus(ctx context.Context, messageId, userId uint64) error {
+	return db.engine.InTransaction(func(rw sqlr.ReaderWriter) error {
+		return codeflow.Try(
+			func() error {
+				return rw.Write(ctx, sqlr.NewQuery(queries.ForumMessageVoteInsert).WithArgs(userId, messageId, 1)).Error
+			},
+			func() error {
+				return rw.Write(ctx, sqlr.NewQuery(queries.ForumMessageVotePlusUpdate).WithArgs(messageId)).Error
+			},
+		)
+	})
+}
+
+func (db *DB) UpdateForumMessageVotedMinus(ctx context.Context, messageId, userId uint64) error {
+	return db.engine.InTransaction(func(rw sqlr.ReaderWriter) error {
+		return codeflow.Try(
+			func() error {
+				return rw.Write(ctx, sqlr.NewQuery(queries.ForumMessageVoteInsert).WithArgs(userId, messageId, -1)).Error
+			},
+			func() error {
+				return rw.Write(ctx, sqlr.NewQuery(queries.ForumMessageVoteMinusUpdate).WithArgs(messageId)).Error
+			},
+		)
+	})
+}
+
+func (db *DB) UpdateForumMessageVoteDeleted(ctx context.Context, messageId uint64) error {
+	return db.engine.InTransaction(func(rw sqlr.ReaderWriter) error {
+		err := codeflow.Try(
+			func() error {
+				return rw.Write(ctx, sqlr.NewQuery(queries.ForumMessageVoteDelete).WithArgs(messageId)).Error
+			},
+			func() error {
+				return rw.Write(ctx, sqlr.NewQuery(queries.ForumMessageVoteCountUpdateByModerator).WithArgs(messageId)).Error
+			},
+		)
+		if dbtools.IsNotFoundError(err) {
+			return nil
+		}
+		return err
+	})
+}

--- a/sources/server/internal/db/queries/forum_votes.go
+++ b/sources/server/internal/db/queries/forum_votes.go
@@ -1,0 +1,55 @@
+package queries
+
+const (
+	ForumMessageUserVoteCount = `
+		SELECT 
+			COUNT(*) 
+		FROM 
+			f_messages_votes 
+		WHERE 
+			user_id = ? AND message_id = ?
+	`
+
+	ForumMessageVoteInsert = `
+		INSERT 
+			f_messages_votes 
+		SET 
+			user_id = ?, message_id = ?, voteone = ?, date_of_vote = NOW()
+	`
+
+	ForumMessageVotePlusUpdate = `
+		UPDATE 
+			f_messages 
+		SET
+			vote_plus = vote_plus + 1
+		WHERE 
+			message_id = ?
+	`
+
+	ForumMessageVoteMinusUpdate = `
+		UPDATE 
+			f_messages 
+		SET 
+			vote_minus = vote_minus - 1
+		WHERE 
+			message_id = ?
+	`
+
+	ForumMessageVoteDelete = `
+		DELETE FROM 
+			f_messages_votes 
+		WHERE 
+			message_id = ?
+	`
+
+	// TODO Неясно, зачем выставляется флаг is_red. Предоложительно, чтобы запретить повторную оценку сообщения после
+	//  удаления его оценки модератором. Но подобное применение флага нивелирует его смысл как стопроцентного индикатора
+	//  модераторского сообщения. Похоже на баг. https://github.com/parserpro/fantlab/issues/945
+	ForumMessageVoteCountUpdateByModerator = `
+		UPDATE 
+			f_messages 
+		SET 
+			is_red = 1, vote_plus = 0, vote_minus = 0 
+		WHERE 
+			message_id = ?`
+)

--- a/sources/server/internal/endpoints/add_forum_message.go
+++ b/sources/server/internal/endpoints/add_forum_message.go
@@ -1,0 +1,118 @@
+package endpoints
+
+import (
+	"fantlab/base/dbtools"
+	"fantlab/pb"
+	"fantlab/server/internal/helpers"
+	"github.com/golang/protobuf/proto"
+	"net/http"
+	"strconv"
+)
+
+func (api *API) AddForumMessage(r *http.Request) (int, proto.Message) {
+	var params struct {
+		// id темы
+		TopicId uint64 `http:"id,path"`
+		// текст сообщения
+		Message string `http:"message,form"`
+	}
+
+	api.bindParams(&params, r)
+
+	if params.TopicId == 0 {
+		return api.badParam("id")
+	}
+
+	availableForums := api.getAvailableForums(r)
+
+	dbTopic, err := api.services.DB().FetchForumTopic(r.Context(), availableForums, params.TopicId)
+
+	if err != nil {
+		if dbtools.IsNotFoundError(err) {
+			return http.StatusNotFound, &pb.Error_Response{
+				Status:  pb.Error_NOT_FOUND,
+				Context: strconv.FormatUint(params.TopicId, 10),
+			}
+		}
+
+		return http.StatusInternalServerError, &pb.Error_Response{
+			Status: pb.Error_SOMETHING_WENT_WRONG,
+		}
+	}
+
+	if dbTopic.IsClosed == 1 {
+		return http.StatusForbidden, &pb.Error_Response{
+			Status:  pb.Error_ACTION_PERMITTED,
+			Context: "Тема закрыта",
+		}
+	}
+
+	user := api.getUser(r)
+
+	userIsForumModerator, err := api.services.DB().FetchUserIsForumModerator(r.Context(), user.UserId, params.TopicId)
+
+	if err != nil {
+		return http.StatusInternalServerError, &pb.Error_Response{
+			Status: pb.Error_SOMETHING_WENT_WRONG,
+		}
+	}
+
+	formattedMessage := helpers.FormatMessage(params.Message)
+
+	messageContainsModerTags := helpers.ContainsModerTags(formattedMessage)
+
+	if !userIsForumModerator && messageContainsModerTags {
+		formattedMessage = helpers.RemoveModerTags(formattedMessage)
+	}
+
+	formattedMessageLength := uint64(len(formattedMessage))
+
+	if formattedMessageLength == 0 {
+		return http.StatusForbidden, &pb.Error_Response{
+			Status:  pb.Error_ACTION_PERMITTED,
+			Context: "Текст сообщения пустой (после форматирования)",
+		}
+	}
+
+	if formattedMessageLength > api.config.MaxForumMessageLength && user.UserId != api.config.BotUserId {
+		return http.StatusForbidden, &pb.Error_Response{
+			Status:  pb.Error_ACTION_PERMITTED,
+			Context: "Текст сообщения слишком длинный (больше 20 тыс. символов после форматирования)",
+		}
+	}
+
+	var isRed uint8
+	if userIsForumModerator && messageContainsModerTags {
+		isRed = 1
+	}
+
+	err = api.services.DB().InsertNewForumMessage(r.Context(), dbTopic, user.UserId, user.Login, formattedMessage, isRed, api.config.ForumMessagesInPage)
+
+	if err != nil {
+		return http.StatusInternalServerError, &pb.Error_Response{
+			Status: pb.Error_SOMETHING_WENT_WRONG,
+		}
+	}
+
+	err = api.services.DeleteUserCache(r.Context(), user.UserId)
+
+	if err != nil {
+		return http.StatusInternalServerError, &pb.Error_Response{
+			Status: pb.Error_SOMETHING_WENT_WRONG,
+		}
+	}
+
+	dbTopicSubscribers, err := api.services.DB().FetchForumTopicSubscribers(r.Context(), dbTopic.TopicId, user.UserId)
+
+	for _, dbTopicSubscriber := range dbTopicSubscribers {
+		err = api.services.DeleteUserCache(r.Context(), dbTopicSubscriber)
+
+		if err != nil {
+			return http.StatusInternalServerError, &pb.Error_Response{
+				Status: pb.Error_SOMETHING_WENT_WRONG,
+			}
+		}
+	}
+
+	return http.StatusOK, &pb.Common_SuccessResponse{}
+}

--- a/sources/server/internal/endpoints/show_article.go
+++ b/sources/server/internal/endpoints/show_article.go
@@ -36,7 +36,7 @@ func (api *API) ShowArticle(r *http.Request) (int, proto.Message) {
 		}
 	}
 
-	err = api.services.SetBlogArticleLikeCount(r.Context(), params.ArticleId, dbTopic.LikesCount)
+	err = api.services.SetBlogArticleLikeCountCache(r.Context(), params.ArticleId, dbTopic.LikesCount)
 
 	if err != nil {
 		return http.StatusInternalServerError, &pb.Error_Response{

--- a/sources/server/internal/endpoints/toggle_article_like.go
+++ b/sources/server/internal/endpoints/toggle_article_like.go
@@ -66,7 +66,7 @@ func (api *API) ToggleArticleLike(r *http.Request) (int, proto.Message) {
 		}
 	}
 
-	err = api.services.SetBlogArticleLikeCount(r.Context(), params.ArticleId, dbTopicLikeCount)
+	err = api.services.SetBlogArticleLikeCountCache(r.Context(), params.ArticleId, dbTopicLikeCount)
 
 	if err != nil {
 		return http.StatusInternalServerError, &pb.Error_Response{

--- a/sources/server/internal/endpoints/toggle_forum_message_voting.go
+++ b/sources/server/internal/endpoints/toggle_forum_message_voting.go
@@ -60,7 +60,7 @@ func (api *API) SetForumMessageVoting(r *http.Request) (int, proto.Message) {
 		}
 	}
 
-	userIsForumModerator, err := api.services.DB().FetchUserIsForumModerator(r.Context(), userId, params.MessageId)
+	userIsForumModerator, err := api.services.DB().FetchUserIsForumModerator(r.Context(), userId, message.TopicId)
 
 	if err != nil {
 		return http.StatusInternalServerError, &pb.Error_Response{

--- a/sources/server/internal/helpers/message.go
+++ b/sources/server/internal/helpers/message.go
@@ -1,0 +1,54 @@
+package helpers
+
+import "regexp"
+
+var (
+	carriageReturnRegex       = regexp.MustCompile("\r")
+	whitespaceCharactersRegex = regexp.MustCompile("\\s+$")
+	onlySpacesStringRegex     = regexp.MustCompile(" +\n")
+	headNewlines              = regexp.MustCompile("^\n+")
+	tooManyNewlines           = regexp.MustCompile("\n{4,}")
+	moderTagsRegex            = regexp.MustCompile("(?i)\\[moder](.*)\\[/moder]")
+	quoteTagsRegex            = regexp.MustCompile("(?i)\\[q](.*)\\[/q]")
+	nonRussianCharactersRegex = regexp.MustCompile("[^А-Яа-я]")
+)
+
+// Чистим сообщение от лишних пробельных символов
+func FormatMessage(message string) string {
+	result := message
+
+	// удаляем символ возврата каретки
+	result = carriageReturnRegex.ReplaceAllLiteralString(result, "")
+	// удаляем пробелы и переводы строки в конце сообщения
+	result = whitespaceCharactersRegex.ReplaceAllLiteralString(result, "")
+	// удаляем пробелы, если строка состоит только из них
+	result = onlySpacesStringRegex.ReplaceAllLiteralString(result, "\n")
+	// удаляем переводы строки в начале сообщения
+	result = headNewlines.ReplaceAllLiteralString(result, "")
+	// если переводов строки больше 3, оставляем 3
+	result = tooManyNewlines.ReplaceAllLiteralString(result, "\n\n\n")
+
+	return result
+}
+
+// Проверяем сообщение на наличие тегов [moder]...[/moder], поиск регистронезависимый
+func ContainsModerTags(message string) bool {
+	return moderTagsRegex.MatchString(message)
+}
+
+// Удаляем теги [moder]...[/moder], поиск регистронезависимый
+func RemoveModerTags(message string) string {
+	return moderTagsRegex.ReplaceAllString(message, "$1")
+}
+
+// Удаляем символы, которые не будут участвовать в вычислении длины сообщения
+func RemoveImmeasurable(message string) string {
+	result := message
+
+	// удаляем цитаты
+	result = quoteTagsRegex.ReplaceAllLiteralString(result, "")
+	// удаляем все нерусские символы
+	result = nonRussianCharactersRegex.ReplaceAllLiteralString(result, "")
+
+	return result
+}

--- a/sources/server/internal/router/routes.go
+++ b/sources/server/internal/router/routes.go
@@ -46,6 +46,7 @@ func Routes(config *config.AppConfig, services *app.Services, pathParamGetter en
 			g.Subgroup("С проверкой на бан", func(g *routing.Group) {
 				g.Middleware(middlewares.CheckBan(services))
 
+				g.Endpoint("POST", "/topics/{id}/message", api.AddForumMessage, "Создание нового сообщения в форуме")
 				g.Endpoint("PUT", "/topics/{id}/subscription", api.ToggleForumTopicSubscription, "Подписка/отписка от темы форума")
 				g.Endpoint("PUT", "/communities/{id}/subscription", api.ToggleCommunitySubscription, "Вступление/выход из сообщества")
 				g.Endpoint("PUT", "/blogs/{id}/subscription", api.ToggleBlogSubscription, "Подписка/отписка от блога")

--- a/sources/server/server.go
+++ b/sources/server/server.go
@@ -78,15 +78,17 @@ func makeCryptoCoder() *edsign.Coder {
 
 func makeConfig(imagesBaseURL string) *config.AppConfig {
 	return &config.AppConfig{
-		ImagesBaseURL:       imagesBaseURL,
-		BlogsInPage:         50,
-		BlogTopicsInPage:    5,
-		ForumTopicsInPage:   20,
-		ForumMessagesInPage: 20,
+		ImagesBaseURL:         imagesBaseURL,
+		BlogsInPage:           50,
+		BlogTopicsInPage:      5,
+		ForumTopicsInPage:     20,
+		ForumMessagesInPage:   20,
+		MaxForumMessageLength: 20000,
 		// https://github.com/parserpro/fantlab/blob/ea456f3e8b8f9e02ab13ca2cdb9c335d36884d93/config/main.cfg#L402
 		// 20 (один из первоапрельских форумов) убрал из списка
 		DefaultAccessToForums: []uint64{1, 2, 3, 5, 6, 7, 8, 10, 12, 13, 14, 15, 16, 17, 22},
 		// https://github.com/parserpro/fantlab/blob/ce769f66c5eacd59f487de840eb4bf62cac733a2/config/misc.cfg#L71
 		CensorshipText: "Сообщение изъято модератором",
+		BotUserId:      2, // Р. Букашка
 	}
 }


### PR DESCRIPTION
Сделано добавление нового сообщения в форуме. Запросы отчасти поменяны местами для большей эффективности и логически разбиты на отдельные куски, выполняются все в рамках одной транзакции, в отличие от текущей реализации. В то же время, опущены некоторые детали (в порядке их появления в методе [Forum#AddNewMessage](https://github.com/parserpro/fantlab/blob/b519d8cc4e03790a885d455c648f808daf8069dc/pm/Forum.pm#L2711)):
1. Пропущены многочисленные вкрапления кода, которые никак не влияют на дальнейшую работу: `$force`, `$bonus` etc
2. Полностью пропущен [код работы с аттачами](https://github.com/parserpro/fantlab/blob/b519d8cc4e03790a885d455c648f808daf8069dc/pm/Forum.pm#L2824-L2840)
3. Пропущено [удаление файла](https://github.com/parserpro/fantlab/blob/b519d8cc4e03790a885d455c648f808daf8069dc/pm/Forum.pm#L2008) с текстом превью сообщения для данной темы
4. Пропущено [сохранение](https://github.com/parserpro/fantlab/blob/b519d8cc4e03790a885d455c648f808daf8069dc/pm/Forum.pm#L2634-L2649) текста сообщения в файл. На самом деле непонятно, зачем вообще существуют файлы с текстом сообщений форума
5. Пропущен [аплоад аттачей](https://github.com/parserpro/fantlab/blob/b519d8cc4e03790a885d455c648f808daf8069dc/pm/Forum.pm#L2909-L2924) (дубль 2?)
6. Также пропущено [выставление флага](https://github.com/parserpro/fantlab/blob/b519d8cc4e03790a885d455c648f808daf8069dc/pm/Forum.pm#L4762-L4770) о наличии аттача у сообщения
7. Опущено [условие](https://github.com/parserpro/fantlab/blob/b519d8cc4e03790a885d455c648f808daf8069dc/pm/Forum.pm#L2948-L2952) про непосылание юзеру нотификации о новом сообщении в форуме, если его нет больше 2 лет на сайте. С одной стороны, это несоответствие текущей логике, с другой - это позволило не реализовывать аналог абсолютно чудовищного метода [MemcachedFunctions#MC_GetUserActivityTime](https://github.com/parserpro/fantlab/blob/b519d8cc4e03790a885d455c648f808daf8069dc/pm/MemcachedFunctions.pm#L328-L371). Да и ничего страшного в том, что сообщение рассылается, нет: пользователю без разницы, а нагрузка на базу совсем небольшая.

Чуть не забыл. По ходу разбирательств с текущей логикой нашел баги, как обычно, пометил их `TODO`. По-хорошему, править их надо и в перле тоже.

И еще. Есть баг с тем, что твое твое собственное сообщение, отправленное через API, отображается как непрочитанное при открытии темы на сайте. Пока не очень понятно, как править.