### PR TITLE
FLGO-215 Forum message text cache invalidation

### DIFF
--- a/docker-compose/app.yml
+++ b/docker-compose/app.yml
@@ -15,5 +15,4 @@ services:
       - flnetwork
     volumes:
       - ./cache/:/cache
-      - ./public/files/messages/:/forum_attach
     env_file: app.env

--- a/sources/core/db/errors.go
+++ b/sources/core/db/errors.go
@@ -1,7 +1,10 @@
 package db
 
-import "database/sql"
+import (
+	"database/sql"
+	"github.com/FantLab/go-kit/database/rowscanner"
+)
 
 func IsNotFoundError(err error) bool {
-	return err == sql.ErrNoRows
+	return err == sql.ErrNoRows || err == rowscanner.ErrInvalidRowCount /* нет результатов при сканировании в скаляр */
 }

--- a/sources/core/helpers/common.go
+++ b/sources/core/helpers/common.go
@@ -1,6 +1,9 @@
 package helpers
 
-import "regexp"
+import (
+	"fmt"
+	"regexp"
+)
 
 // Любые непробельные символы, кроме / (чтобы не создавать проблем с путями в URL), + пробел
 var fileNameRegex = regexp.MustCompile(`^[^\f\n\r\t\v/]+$`)
@@ -24,4 +27,8 @@ func CalculatePageCount(totalCount, limit uint64) uint64 {
 		pageCount++
 	}
 	return pageCount
+}
+
+func IdToRelativeFilePath(id uint64) string {
+	return fmt.Sprintf("%d/%d/%d/%d", id/10000, id/1000, id/100, id)
 }


### PR DESCRIPTION
Фактически, вместо инвалидации кеш просто удаляется. Иначе придется тащить весь вот этот кусок кода в Go: https://github.com/parserpro/fantlab/blob/37aee768019dd46847a22664d173273fa71e0e4d/pm/Functions.pm#L469-L615